### PR TITLE
[INT-203] Removed disturbing validation

### DIFF
--- a/oauth-config.js
+++ b/oauth-config.js
@@ -61,18 +61,12 @@ const config = convict({
       doc: "State parameter for oauth 2.0 specification - for DD-based functions, must be stringified JSON because it passes DD JWT data inside",
       format: String,
       default: undefined
-    },
-    page: {
-      doc: "Page parameter",
-      format: String,
-      default: undefined
     }
   }
 });
 
 module.exports.setConfig = function(configuration) {
   config.load(configuration);
-  config.validate({allowed: 'strict'});
 
   // This formats the callback url dynamically based on the deployed function
   // name. For example the function name of fn-123456789 would be inserted into

--- a/oauth-config.js
+++ b/oauth-config.js
@@ -61,6 +61,11 @@ const config = convict({
       doc: "State parameter for oauth 2.0 specification - for DD-based functions, must be stringified JSON because it passes DD JWT data inside",
       format: String,
       default: undefined
+    },
+    page: {
+      doc: "Page parameter",
+      format: String,
+      default: undefined
     }
   }
 });


### PR DESCRIPTION
## Jira
https://dronedeploy.atlassian.net/browse/INT-203

## Work done
Removed convict.validate as it only validates if there are some fields in config which aren't defined in the schema, where we would like to have some other fields, e.g. `page` field in climate. Convict only validates types (but we use string only) and that only predefiened fields exist - so this validation isn't valuable in this code and is problematic.

## Related PRs
https://github.com/dronedeploy/apps/pull/91