### PR TITLE
Remove authentication check from auth/callback route [INT-223]

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "authRequired": true,
+  "ignoreAuthRoutes": ["/auth/callback"],
   "mockToken": false,
   "config": {
     "cors": {

--- a/handler.js
+++ b/handler.js
@@ -195,7 +195,7 @@ const storeTokenHandler = (req, res, ctx) => {
   try {
     createTokenObject(parsed.token);
   } catch (e) {
-    return res.status(500).send(createErrorHtml(e.message));
+    return res.status(500).send(packageError(e.message));
   }
 
   // Get our oauth table and store the token data

--- a/handler.js
+++ b/handler.js
@@ -31,6 +31,9 @@ exports.routeHandler = function (req, res, ctx) {
       // and return a response to the client
       oauth2CallbackHandler(req, res, ctx);
       break;
+    case '/token':
+      storeTokenHandler(req, res, ctx);
+      break;
     case '/logout':
       logoutHandler(req, res, ctx);
       break;
@@ -117,36 +120,35 @@ const storeTokenData = (table, username, tokenData, res, isRefresh) => {
   // Some tokens may not have an 'expires_at' property, so we will
   // calculate it anyway based on the 'expires_in' value
   const accessTokenObj = oauth2.accessToken.create(tokenData);
-  return table.upsertRow(username, {
+  return table.upsertRow(username, createTokenObject(tokenData))
+    .then((rowData) => {
+      if (!rowData.ok) {
+        // Problem storing the access token which will
+        // impact potential future api calls - send error
+        throw new Error(JSON.stringify(rowData.errors[0]));
+      }
+
+      if (isRefresh) {
+        return res.status(200).send(accessTokenObj.token);
+      }
+      return res.status(200).send(generateCallbackHtml(accessTokenObj.token));
+    });
+};
+
+const createTokenObject = (tokenData) => {
+  const accessTokenObj = oauth2.accessToken.create(tokenData);
+  return {
     accessToken: accessTokenObj.token.access_token,
     access_expires_at: accessTokenObj.token.expires_at,
-    refreshToken: accessTokenObj.token.refresh_token}
-  ).then((rowData) => {
-    if (!rowData.ok) {
-      // Problem storing the access token which will
-      // impact potential future api calls - send error
-      throw new Error(JSON.stringify(rowData.errors[0]));
-    }
-
-    if (isRefresh) {
-      return res.status(200).send(accessTokenObj.token);
-    }
-    return res.status(200).send(generateCallbackHtml(accessTokenObj.token));
-  });
+    refreshToken: accessTokenObj.token.refresh_token,
+  };
 };
 
 // Initializes the OAuth2 flow - successful authorization results in redirect to callback export
 const oauth2InitHandler = (req, res, ctx) => {
   provider.authorizeUrl.redirect_uri = `${provider.callbackUrl}`;
-  provider.authorizeUrl.state = setupStateParam(ctx);
   const authorizationUri = oauth2.authorizationCode.authorizeURL(provider.authorizeUrl);
   res.send(authorizationUri);
-};
-
-const setupStateParam = (ctx) => {
-  const obj = provider.authorizeUrl.state ? JSON.parse(provider.authorizeUrl.state) : {};
-  obj.jwt_token = ctx.originalToken;
-  return JSON.stringify(obj);
 };
 
 // Callback handler to take the auth code from first OAuth2 step and get the tokens
@@ -159,20 +161,44 @@ const oauth2CallbackHandler = (req, res, ctx) => {
   // Save the access token
   return oauth2.authorizationCode.getToken(tokenConfig)
     .then((result) => {
-      // Result will contain: user, access token and refresh token
-      // Get our oauth table and store the token data
-      return tableUtils.setupOAuthTable(ctx)
-        .then((tableId) => {
-          var accessTokensTable = ctx.datastore.table(tableId);
-
-          // we store the access token data by associating
-          // it with the user on the function jwt auth token
-          return storeTokenData(accessTokensTable, ctx.token.username, result, res);
-        });
+      return res.status(200).send(generateCallbackHtml(createTokenObject(result)));
     })
     .catch((error) => {
-      console.log('Access Token Error', error.message);
-      res.status(500).send(createErrorHtml(error.message));
+      console.log('OAuth Callback Error', error.message);
+      return res.status(500).send(createErrorHtml(error.message));
+    });
+};
+
+const storeTokenHandler = (req, res, ctx) => {
+  // Make sure this is called with the proper method
+  if (req.method !== 'POST' && req.method !== 'PUT') {
+    return res.status(400).send(createErrorHtml('Invalid request method - please use POST or PUT'));
+  }
+
+  // Make sure user has passed correct data parameter
+  if (!req.body || !req.body.token) {
+    return res.status(400).send(createErrorHtml('Missing token body in request'));
+  }
+
+  // Make sure data passed actually converts properly
+  try {
+    createTokenObject(req.body.token);
+  } catch (e) {
+    return res.status(500).send(createErrorHtml(e.message));
+  }
+
+  // Get our oauth table and store the token data
+  return tableUtils.setupOAuthTable(ctx)
+    .then((tableId) => {
+      var accessTokensTable = ctx.datastore.table(tableId);
+
+      // we store the access token data by associating
+      // it with the user on the function jwt auth token
+      return storeTokenData(accessTokensTable, ctx.token.username, req.body.token, res);
+    })
+    .catch((error) => {
+      console.log('Error storing Access Token', error.message);
+      return res.status(500).send(createErrorHtml(error.message));
     });
 };
 

--- a/handler.js
+++ b/handler.js
@@ -100,7 +100,9 @@ const packageError = (err) => {
 };
 
 const isEmptyToken = (data) => {
-  return data.accessToken === "" || data.refreshToken === "";
+  const isUndefined = (!data.accessToken || !data.refreshToken);
+  const isEmpty = (data.accessToken === "" || data.refreshToken === "");
+  return isUndefined || isEmpty;
 };
 
 const doesTokenNeedRefresh = (token) => {

--- a/handler.js
+++ b/handler.js
@@ -133,10 +133,7 @@ const storeTokenData = (table, username, tokenData, res, isRefresh) => {
         throw new Error(JSON.stringify(rowData.errors[0]));
       }
 
-      if (isRefresh) {
-        return res.status(200).send(accessTokenObj.token);
-      }
-      return res.status(200).send(generateCallbackHtml(accessTokenObj.token));
+      return res.status(200).send(accessTokenObj.token);
     });
 };
 

--- a/handler.js
+++ b/handler.js
@@ -170,8 +170,9 @@ const oauth2CallbackHandler = (req, res, ctx) => {
 };
 
 const storeTokenHandler = (req, res, ctx) => {
-  console.log(req);
   console.log(req.body);
+  console.log(req.body.token);
+  console.log((!req.body || !req.body.token));
   // Make sure this is called with the proper method
   if (req.method !== 'POST' && req.method !== 'PUT') {
     return res.status(400).send(createErrorHtml('Invalid request method - please use POST or PUT'));

--- a/handler.js
+++ b/handler.js
@@ -172,6 +172,9 @@ const oauth2CallbackHandler = (req, res, ctx) => {
 const storeTokenHandler = (req, res, ctx) => {
   console.log(req.body);
   console.log(req.body.token);
+  const parsed = JSON.parse(req.body);
+  console.log(parsed);
+  console.log(parsed.token)
   console.log((!req.body || !req.body.token));
   // Make sure this is called with the proper method
   if (req.method !== 'POST' && req.method !== 'PUT') {

--- a/handler.js
+++ b/handler.js
@@ -170,25 +170,25 @@ const oauth2CallbackHandler = (req, res, ctx) => {
 };
 
 const storeTokenHandler = (req, res, ctx) => {
-  console.log(req.body);
-  console.log(req.body.token);
-  const parsed = JSON.parse(req.body);
-  console.log(parsed);
-  console.log(parsed.token)
-  console.log((!req.body || !req.body.token));
   // Make sure this is called with the proper method
   if (req.method !== 'POST' && req.method !== 'PUT') {
-    return res.status(400).send(createErrorHtml('Invalid request method - please use POST or PUT'));
+    return res.status(400).send(packageError('Invalid request method - please use POST or PUT'));
   }
 
+  if (!req.body) {
+    return res.status(400).send(packageError('Missing request body'));
+  }
+
+  const parsed = JSON.parse(req.body);
+
   // Make sure user has passed correct data parameter
-  if (!req.body || !req.body.token) {
-    return res.status(400).send(createErrorHtml('Missing token body in request'));
+  if (!parsed.token) {
+    return res.status(400).send(packageError('Missing token body in request'));
   }
 
   // Make sure data passed actually converts properly
   try {
-    createTokenObject(req.body.token);
+    createTokenObject(parsed.token);
   } catch (e) {
     return res.status(500).send(createErrorHtml(e.message));
   }
@@ -200,11 +200,11 @@ const storeTokenHandler = (req, res, ctx) => {
 
       // we store the access token data by associating
       // it with the user on the function jwt auth token
-      return storeTokenData(accessTokensTable, ctx.token.username, req.body.token, res);
+      return storeTokenData(accessTokensTable, ctx.token.username, parsed.token, res);
     })
     .catch((error) => {
       console.log('Error storing Access Token', error.message);
-      return res.status(500).send(createErrorHtml(error.message));
+      return res.status(500).send(packageError(error.message));
     });
 };
 

--- a/handler.js
+++ b/handler.js
@@ -66,9 +66,8 @@ const refreshHandler = (req, res, ctx) => {
             expires_at: result.data.access_expires_at,
             refresh_token: result.data.refreshToken
           };
-          console.log(tokenData);
           const accessTokenObj = oauth2.accessToken.create(tokenData);
-          console.log(accessTokenObj);
+
           // We preemptively refresh the token to avoid sending a token back
           // to the client that may expire very soon
           if (doesTokenNeedRefresh(accessTokenObj.token)) {
@@ -79,7 +78,6 @@ const refreshHandler = (req, res, ctx) => {
                 return storeTokenData(accessTokensTable, ctx.token.username, refreshResult.token, res, true);
               })
               .catch((err) => {
-                console.log(err);
                 return res.status(500).send(packageError(err.message));
               });
           }
@@ -129,14 +127,14 @@ const storeTokenData = (table, username, tokenData, res, isRefresh) => {
     access_expires_at: accessTokenObj.token.expires_at,
     refreshToken: accessTokenObj.token.refresh_token}
   ).then((rowData) => {
-      if (!rowData.ok) {
-        // Problem storing the access token which will
-        // impact potential future api calls - send error
-        throw new Error(JSON.stringify(rowData.errors[0]));
-      }
+    if (!rowData.ok) {
+      // Problem storing the access token which will
+      // impact potential future api calls - send error
+      throw new Error(JSON.stringify(rowData.errors[0]));
+    }
 
-      return res.status(200).send(accessTokenObj.token);
-    });
+    return res.status(200).send(accessTokenObj.token);
+  });
 };
 
 // Initializes the OAuth2 flow - successful authorization results in redirect to callback export

--- a/handler.js
+++ b/handler.js
@@ -45,7 +45,6 @@ exports.routeHandler = function (req, res, ctx) {
 const refreshHandler = (req, res, ctx) => {
   return tableUtils.setupOAuthTable(ctx)
     .then((tableId) => {
-      console.log(`refreshHandler OAuth table id: ${tableId}`);
       const accessTokensTable = ctx.datastore.table(tableId);
 
       console.log(`refreshHandler - attempting datastore get with ${ctx.token.username}`);
@@ -89,7 +88,7 @@ const refreshHandler = (req, res, ctx) => {
           }
 
           // No refresh needed, return token like normal
-          console.log(`refreshHandler - no refresh needed returning ${tokenData.access_token}`);
+          console.log(`refreshHandler - no refresh needed returning ${JSON.stringify(tokenData.access_token)}`);
           return res.status(200).send(tokenData.access_token);
         })
     })
@@ -129,17 +128,17 @@ const storeTokenData = (table, username, tokenData, res, isRefresh) => {
   // Some tokens may not have an 'expires_at' property, so we will
   // calculate it anyway based on the 'expires_in' value
   const accessTokenObj = oauth2.accessToken.create(tokenData);
-  console.log(`storeTokenData::accessTokenObj = ${accessTokenObj}`);
+  console.log(`storeTokenData::accessTokenObj = ${JSON.stringify(accessTokenObj)}`);
   return table.upsertRow(username, createTokenObject(tokenData))
     .then((rowData) => {
-      console.log(`storeTokenData::upsert result - ${rowData}`);
+      console.log(`storeTokenData::upsert result - ${JSON.stringify(rowData)}`);
       if (!rowData.ok) {
         // Problem storing the access token which will
         // impact potential future api calls - send error
         throw new Error(JSON.stringify(rowData.errors[0]));
       }
 
-      console.log(`storeTokenData returning 200 ${accessTokenObj.token}`);
+      console.log(`storeTokenData returning 200 ${JSON.stringify(accessTokenObj.token)}`);
       return res.status(200).send(accessTokenObj.token);
     });
 };
@@ -151,7 +150,7 @@ const createTokenObject = (tokenData) => {
     access_expires_at: accessTokenObj.token.expires_at,
     refreshToken: accessTokenObj.token.refresh_token,
   };
-  console.log(`createTokenObject returning ${res}`);
+  console.log(`createTokenObject returning ${JSON.stringify(res)}`);
   return res;
 };
 
@@ -192,7 +191,7 @@ const storeTokenHandler = (req, res, ctx) => {
   }
 
   const parsed = JSON.parse(req.body);
-  console.log(`Parsed request.body: ${parsed}`);
+  console.log(`Parsed request.body: ${JSON.stringify(parsed)}`);
 
   // Make sure user has passed correct data parameter
   if (!parsed.token) {
@@ -210,12 +209,11 @@ const storeTokenHandler = (req, res, ctx) => {
   // Get our oauth table and store the token data
   return tableUtils.setupOAuthTable(ctx)
     .then((tableId) => {
-      console.log(`OAuth TableId: ${tableId}`);
       var accessTokensTable = ctx.datastore.table(tableId);
 
       // we store the access token data by associating
       // it with the user on the function jwt auth token
-      console.log(`Calling storeTokenData with: ${ctx.token.username} and ${parsed.token}`);
+      console.log(`Calling storeTokenData with: ${ctx.token.username} and ${JSON.stringify(parsed.token)}`);
       return storeTokenData(accessTokensTable, ctx.token.username, parsed.token, res);
     })
     .catch((error) => {

--- a/handler.js
+++ b/handler.js
@@ -49,6 +49,7 @@ const refreshHandler = (req, res, ctx) => {
 
       return accessTokensTable.getRowByExternalId(ctx.token.username)
         .then((result) => {
+          console.log(result);
           if (!result.ok) {
             if (couldNotFindData(result)) {
               return res.status(401).send();
@@ -66,8 +67,9 @@ const refreshHandler = (req, res, ctx) => {
             expires_at: result.data.access_expires_at,
             refresh_token: result.data.refreshToken
           };
+          console.log(tokenData);
           const accessTokenObj = oauth2.accessToken.create(tokenData);
-
+          console.log(accessTokenObj);
           // We preemptively refresh the token to avoid sending a token back
           // to the client that may expire very soon
           if (doesTokenNeedRefresh(accessTokenObj.token)) {
@@ -78,6 +80,7 @@ const refreshHandler = (req, res, ctx) => {
                 return storeTokenData(accessTokensTable, ctx.token.username, refreshResult.token, res, true);
               })
               .catch((err) => {
+                console.log(err);
                 return res.status(500).send(packageError(err.message));
               });
           }

--- a/handler.js
+++ b/handler.js
@@ -170,6 +170,8 @@ const oauth2CallbackHandler = (req, res, ctx) => {
 };
 
 const storeTokenHandler = (req, res, ctx) => {
+  console.log(req);
+  console.log(req.body);
   // Make sure this is called with the proper method
   if (req.method !== 'POST' && req.method !== 'PUT') {
     return res.status(400).send(createErrorHtml('Invalid request method - please use POST or PUT'));

--- a/oauth-config.js
+++ b/oauth-config.js
@@ -56,11 +56,6 @@ const config = convict({
       doc: "Authorization scope being requested from the OAuth provider",
       format: String,
       default: undefined
-    },
-    state: {
-      doc: "State parameter for oauth 2.0 specification - for DD-based functions, must be stringified JSON because it passes DD JWT data inside",
-      format: String,
-      default: undefined
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "@dronedeploy/function-wrapper": "1.1.2",
+    "@dronedeploy/function-wrapper": "1.1.5",
     "convict": "4.2.0",
     "simple-oauth2": "1.5.2",
     "string-format": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "@dronedeploy/function-wrapper": "1.1.5",
+    "@dronedeploy/function-wrapper": "1.1.6",
     "convict": "4.2.0",
     "simple-oauth2": "1.5.2",
     "string-format": "2.0.0"


### PR DESCRIPTION
## Ticket
https://dronedeploy.atlassian.net/browse/INT-223

## Work Done
- Add `/auth/callback` to `function-wrapper` configuration for ignoring auth
- Add new `/token` route to actually store the access token to datastore
- Remove code related to the state parameter

By ignoring the JWT check on the /auth/callback (accessed by oauth provider), we simplify everything, but it does require separate call from UI app client side to store the token.