### PR TITLE
[INT-283] Allow to set useBasicAuthorizationHeader

### DIFF
--- a/oauth-config.js
+++ b/oauth-config.js
@@ -45,6 +45,13 @@ const config = convict({
         default: undefined
       }
     },
+    options: {
+      useBasicAuthorizationHeader: {
+        doc: "Whether or not the Basic Authorization header should be sent at the token request",
+        format: "Boolean",
+        default: undefined
+      }
+    }
   },
   authorizeUrl: {
     redirect_uri: {


### PR DESCRIPTION
We need to be able to disable this option for Autodesk's oauth to work.
