### PR TITLE
[INT-598] Add OAuth2 client credentials token refresh support

### DIFF
--- a/handlers/clientCredentials.js
+++ b/handlers/clientCredentials.js
@@ -1,0 +1,76 @@
+const oauth2 = require('simple-oauth2');
+const tableUtils = require('../datastore/table');
+
+
+exports.initHandler = function(config) {
+  const handlerClass = new ClientCredentialsHandler(config);
+  return handlerClass.getRoutes();
+};
+
+
+class ClientCredentialsHandler {
+  constructor(config) {
+    this.datastoreExternalId = 'clientCredentialsToken';
+    this.expirationWindowInSeconds = 300;
+    this.tokenConfig = config.get('tokenConfig');
+    this.oauth2 = oauth2.create(config.get('credentials'));
+  }
+
+  getRoutes() {
+    return {
+      '/refreshClientCredentials': this.refreshClientCredentialsHandler.bind(this),
+    }
+  }
+
+  refreshClientCredentialsHandler(req, res, ctx) {
+    return tableUtils.setupOAuthTable(ctx)
+      .then((tableId) => ctx.datastore.table(tableId))
+      .then((table) => {
+        return table.getRowByExternalId(this.datastoreExternalId)
+          .then((row) => {
+            const needRefresh = !row.ok || this.doesTokenNeedRefresh(row.data);
+            if (needRefresh) {
+              return this.refreshClientCredentials(this.tokenConfig)
+                .then((tokenObj) => this.storeClientCredentialsToken(table, tokenObj))
+                .then((tokenObj) => (tokenObj.accessToken));
+            }
+            return Promise.resolve(row.data.accessToken);
+          })
+          .then((accessToken) => res.status(200).send(accessToken));
+      })
+      .catch((error) => {
+        const msg = 'Refresh client credentials token failed';
+        console.error(msg, error);
+        return res.status(500).send(msg);
+      });
+  }
+
+  refreshClientCredentials(tokenConfig) {
+    return this.oauth2.clientCredentials.getToken(tokenConfig)
+      .then((result) => this.oauth2.accessToken.create(result))
+      .then((accessToken) => ({
+        accessToken: accessToken.token.access_token,
+        access_expires_at: accessToken.token.expires_at,
+        refreshToken: ''
+      }));
+  }
+
+  doesTokenNeedRefresh(token) {
+    const isTokenIncomplete = !token.accessToken || !token.access_expires_at;
+    const expirationTimeInSeconds = new Date(token.access_expires_at).getTime() / 1000;
+    const nowInSeconds = new Date().getTime() / 1000;
+    const shouldRefresh = nowInSeconds >= (expirationTimeInSeconds - this.expirationWindowInSeconds);
+    return isTokenIncomplete || shouldRefresh;
+  }
+
+  storeClientCredentialsToken(table, token) {
+    console.log('storeClientCredentialsToken', token);
+    return table.upsertRow(this.datastoreExternalId, token)
+      .then((rowData) => {
+        if (!rowData.ok) {
+          throw new Error(`An error occured while updating token data in Datastore: ${JSON.stringify(rowData.errors)}`);
+        }
+      })
+      .then(() => (token));
+  }
+}

--- a/handlers/clientCredentials.js
+++ b/handlers/clientCredentials.js
@@ -31,12 +31,11 @@ class ClientCredentialsHandler {
             const needRefresh = !row.ok || this.doesTokenNeedRefresh(row.data);
             if (needRefresh) {
               return this.refreshClientCredentials(this.tokenConfig)
-                .then((tokenObj) => this.storeClientCredentialsToken(table, tokenObj))
-                .then((tokenObj) => (tokenObj.accessToken));
+                .then((tokenObj) => this.storeClientCredentialsToken(table, tokenObj));
             }
-            return Promise.resolve(row.data.accessToken);
+            return Promise.resolve();
           })
-          .then((accessToken) => res.status(200).send(accessToken));
+          .then(() => res.status(200).send());
       })
       .catch((error) => {
         const msg = 'Refresh client credentials token failed';
@@ -64,13 +63,11 @@ class ClientCredentialsHandler {
   }
 
   storeClientCredentialsToken(table, token) {
-    console.log('storeClientCredentialsToken', token);
     return table.upsertRow(this.datastoreExternalId, token)
       .then((rowData) => {
         if (!rowData.ok) {
           throw new Error(`An error occured while updating token data in Datastore: ${JSON.stringify(rowData.errors)}`);
         }
-      })
-      .then(() => (token));
+      });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {


### PR DESCRIPTION
## Work done
- Refactored existing code to support separate configuration for client credentials and authorization code oauth flow.
- Added /refreshClientCredentials endpoint which will update (if required) client accessToken in Datastore's "OAuth Table", and return new accessToken.
- Bumped version to 1.1.0.
