### PR TITLE
[INT-729] Catch error when refresh token expires

### DIFF
--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -56,7 +56,8 @@ const refreshHandler = (req, res, ctx) => {
                 return storeTokenData(accessTokensTable, storageTokenInfo, refreshResult.token, res);
               })
               .catch((err) => {
-                return res.status(500).send(packageError(err.message));
+                console.log({err});
+                return res.status(401).send(packageError('The authorization code/refresh token is expired or invalid/redirect_uri must have the same value as in the authorization request.'));
               });
           }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {


### PR DESCRIPTION
### Story:

https://dronedeploy.atlassian.net/browse/INT-729

### Work done

When error occcures during refreshing access_token, e.g. refresh token has expired and it no longer can obtain a new access_token, then we catch this kind of error and return error `401`  instead of `500`to the frontend app. Thanks to this change, user can see SignIn page ang log in into integration once more, saving his new access_token and refresh_token to the datastore.