### PR TITLE
[INT-884] Change handling of refresh token in case of Kloudless API

### DIFF
--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -33,6 +33,9 @@ const refreshHandler = (req, res, ctx) => {
             }
             return res.status(500).send(packageError(result));
           }
+          if (isAccessTokenValidForever(result.data)) {
+            return res.status(200).send();
+          }
           if (isEmptyToken(result.data)) {
             return res.status(204).send();
           }
@@ -87,6 +90,12 @@ const isEmptyToken = (data) => {
   const isUndefined = (!data.accessToken || !data.refreshToken);
   const isEmpty = (data.accessToken === "" || data.refreshToken === "");
   return isUndefined || isEmpty;
+};
+
+const isAccessTokenValidForever = (data) => {
+  const isRefreshTokenEmpty = data.refreshToken === "";
+  const isAccessTokenGoodForever = data.accessToken !== "" && data.access_expires_at === '1970-01-01T00:00:00.000Z';
+  return isRefreshTokenEmpty && isAccessTokenGoodForever;
 };
 
 const doesTokenNeedRefresh = (token) => {


### PR DESCRIPTION
### **Story:**

https://dronedeploy.atlassian.net/browse/INT-884

### **Work done**
Checking on `refresh` request, in refreshHandler, if refersh_token is empty and access_token is present and its expiration date is `1970-01-01T00:00:00.000Z`. It should only work for Kloudless. 