### PR TITLE
[INT-884] Change handling of refresh token in case of Kloudless API

### DIFF
--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -33,6 +33,9 @@ const refreshHandler = (req, res, ctx) => {
             }
             return res.status(500).send(packageError(result));
           }
+          if (isAccessTokenValidForever(result.data)) {
+            return res.status(200).send();
+          }
           if (isEmptyToken(result.data)) {
             return res.status(204).send();
           }
@@ -87,6 +90,12 @@ const isEmptyToken = (data) => {
   const isUndefined = (!data.accessToken || !data.refreshToken);
   const isEmpty = (data.accessToken === "" || data.refreshToken === "");
   return isUndefined || isEmpty;
+};
+
+const isAccessTokenValidForever = (data) => {
+  const isRefreshTokenEmpty = data.refreshToken === "";
+  const isAccessTokenGoodForever = data.accessToken !== "" && data.access_expires_at === '1970-01-01T00:00:00.000Z';
+  return isRefreshTokenEmpty && isAccessTokenGoodForever;
 };
 
 const doesTokenNeedRefresh = (token) => {

--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -93,9 +93,9 @@ const isEmptyToken = (data) => {
 };
 
 const isAccessTokenValidForever = (data) => {
-  const isRefreshTokenEmpty = data.refreshToken === "";
-  const isAccessTokenGoodForever = data.accessToken !== "" && data.access_expires_at === '1970-01-01T00:00:00.000Z';
-  return isRefreshTokenEmpty && isAccessTokenGoodForever;
+  const isRefreshTokenEmpty = !data.refreshToken;
+  const isForeverAccessToken = !!data.accessToken && data.access_expires_at === '1970-01-01T00:00:00.000Z';
+  return isRefreshTokenEmpty && isForeverAccessToken;
 };
 
 const doesTokenNeedRefresh = (token) => {

--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -92,10 +92,8 @@ const isEmptyToken = (data) => {
   return isUndefined || isEmpty;
 };
 
-const isAccessTokenValidForever = (data) => {
-  const isRefreshTokenEmpty = !data.refreshToken;
-  const isForeverAccessToken = !!data.accessToken && data.access_expires_at === '1970-01-01T00:00:00.000Z';
-  return isRefreshTokenEmpty && isForeverAccessToken;
+const isAccessTokenValidForever = ({ refreshToken, accessToken, access_expires_at }) => {
+  return !refreshToken && !!accessToken && access_expires_at === '1970-01-01T00:00:00.000Z';
 };
 
 const doesTokenNeedRefresh = (token) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {


### PR DESCRIPTION
### **Story:**

https://dronedeploy.atlassian.net/browse/INT-884

### **Work done**

Checking on refresh request, in refreshHandler, if refersh_token is empty and access_token is present and its expiration date is 1970-01-01T00:00:00.000Z. It should only work for Kloudless.