### PR TITLE
[INT-923] Autodesk BIM 360 integration is broken unless service_account tokens exist in OAuth table

### DIFF
--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -29,7 +29,7 @@ const refreshHandler = (req, res, ctx) => {
         .then((result) => {
           if (!result.ok) {
             if (couldNotFindData(result)) {
-              return res.status(401).send();
+              return res.status(401).send(packageError(result));
             }
             return res.status(500).send(packageError(result));
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {


### PR DESCRIPTION
### CHECKLIST

- [x] I have finished work on the implementation
- [x] I have added the ticket number (AM-123) to the PR name
- ~[ ] I have added documentation about my feature in the README.md (if applicable)~
- ~[] I have covered behaviour of my feature/change with unit tests~
- [x] I have used my feature and thought about the user's perspective
- ~[ ] I have included steps to QA~

### Story:

https://dronedeploy.atlassian.net/browse/INT-923

### Work done
Add data to response for better error handling in `apps` repo when trying to refresh serviceAccount token which is not in the OAuth table.
