### PR TITLE
[INT-1139] Add 'innerAuthorizationUrl' to oauth template

### DIFF
--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -38,9 +38,9 @@ const refreshHandler = (req, res, ctx) => {
 
           if (!!result.data.accessToken) {
 
-              const status = await getInnerAuthorizationResponse(result.data.accessToken);
+              const innerAuthorized = await getInnerAuthorizationResponse(result.data.accessToken);
 
-              if (status === 401 || status === 403) {
+              if (!innerAuthorized) {
                   await accessTokensTable.editRow(storageTokenInfo.externalId, emptyToken);
                   return res.status(401).send();
               }
@@ -84,7 +84,7 @@ const refreshHandler = (req, res, ctx) => {
 };
 
 const getInnerAuthorizationResponse = async (accessToken) => {
-    let status = 200;
+    let authorized = true;
     const url = provider.innerAuthorizationUrl;
     if (url) {
         let options = {
@@ -99,15 +99,15 @@ const getInnerAuthorizationResponse = async (accessToken) => {
         console.info(`Making request: 'GET' ${url}`);
         await fetch(url, options)
             .then((res) => {
-                status = res.status;
+                authorized = res.ok;
             })
             .catch((error) => {
                 console.info({error});
-                status = 401;
+                authorized = false;
                 }
             );
     }
-    return status;
+    return authorized;
 };
 
 const getStorageTokenInfo = (req, ctx) => {

--- a/handlers/authorizationCode.js
+++ b/handlers/authorizationCode.js
@@ -42,7 +42,7 @@ const refreshHandler = (req, res, ctx) => {
 
               if (!innerAuthorized) {
                   await accessTokensTable.editRow(storageTokenInfo.externalId, emptyToken);
-                  return res.status(401).send();
+                  return res.status(204).send();
               }
           }
 

--- a/oauth-config.js
+++ b/oauth-config.js
@@ -65,6 +65,11 @@ const SCHEMA = {
       default: undefined
     }
   },
+  innerAuthorizationUrl: {
+    doc: "Fully qualified url for inner authorization request made during refresh",
+    format: String,
+    default: undefined
+  },
   tokenConfig: {
     scope: {
       doc: "Authorization scope being requested from the OAuth provider",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/oauth-function-template",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Function template providing configurable OAuth 2.0 support for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/oauth-function-template",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@dronedeploy/function-wrapper": "1.1.6",
     "convict": "4.2.0",
+    "node-fetch": "^2.6.0",
     "simple-oauth2": "1.5.2",
     "string-format": "2.0.0"
   }

--- a/template/README.md
+++ b/template/README.md
@@ -21,3 +21,10 @@ CLIENT_SECRET=4095hjfhfjhfeihf3jho3j4hgo34j
 The `authorizeUrl` section pertains to the provider url responsible for authorizing the user. The `scope`
 field is the only **required** field, but additional fields can be added as needed by the provider. Any
 additional fields will be included as query params (`key=value`) for the authorize request.
+
+The `innerAuthorizationUrl` parameter is optional parameter, which is used to make sure that inner 
+service used within outer service is accessible with stored `accessToken`. If this field is not
+empty then for each `/refresh` request this url is called. Field `accessToken` stored in 
+`OAuth Table` is used as authorization token, if given. If url response give back `Unauthorized` or 
+`Forbidden` status, then appropriate `OAuth Table` is cleaned up in the same way as the user
+ logging out.


### PR DESCRIPTION
**Ticket:**
https://dronedeploy.atlassian.net/browse/INT-1139

**Work done:**
New field is added into oauth config template. Implementation is described in `READ.me` file. Http request is called with `node-fetch`.